### PR TITLE
fix quest 任务条件内容修正

### DIFF
--- a/quest/poi.json
+++ b/quest/poi.json
@@ -3369,10 +3369,8 @@
           "flagship": true
         },
         {
-          "ship": "高波改"
-        },
-        {
           "ship": [
+            "高波改",
             "沖波改",
             "朝霜改"
           ],
@@ -10439,7 +10437,7 @@
     ],
     "requirements": {
       "category": "modelconversion",
-      "secretary": "艦",
+      "secretary": "日向改",
       "slots": [
         {
           "slot": 4,
@@ -10449,7 +10447,7 @@
           "use_skilled_crew": true
         }
       ],
-      "equipments": [
+      "consumptions": [
         {
           "name": "九九式艦爆",
           "amount": 2
@@ -14836,13 +14834,12 @@
               "flagship": true
             },
             {
-              "ship": "高波改"
-            },
-            {
-              "ship": "沖波改 "
-            },
-            {
-              "ship": "朝霜改"
+              "ship": [
+                "高波改",
+                "沖波改",
+                "朝霜改"
+              ],
+              "select": 1
             }
           ]
         }


### PR DESCRIPTION
## A83 条件有误

应为长波改二旗舰，并配以【高波改/冲波改/朝霜改三选一】作为僚舰，编成第三一驱逐队第一小队（二船舰队）！

## F58 条件有误

应为以【日向改】为秘书舰，将改修max的瑞云(六三四空)装备在第四个格子，废弃2个桶(运输用)，【准备好2个九九式舰爆和2个瑞云】，并消耗一个熟练搭乘员

## BQ06 条件有误

应为5-4 BOSS点S胜2次。长波改二旗舰，并配以【高波改/冲波改/朝霜改三选一】作为僚舰，加上除此之外的其他舰编成舰队。
