### PR TITLE
fix #12 quest 673 F65 类型错误

### DIFF
--- a/quest/poi.json
+++ b/quest/poi.json
@@ -10819,7 +10819,7 @@
       607
     ],
     "requirements": {
-      "category": "equipexchange",
+      "category": "scrapequipment",
       "scraps": [
         {
           "name": "小口径主砲",


### PR DESCRIPTION
F65 装備開発力の整備
工廠整備任務：装備開発力を整備する。「小口径主砲」系装備x4を廃棄せよ！

任务要求**废弃**`scrapequipment`小口径主砲x4，误写为**准备**`equipexchange`