### PR TITLE
Update quest 	2018年1月17日新任务

### DIFF
--- a/quest/poi.json
+++ b/quest/poi.json
@@ -11019,6 +11019,50 @@
     }
   },
   {
+    "game_id": 677,
+    "wiki_id": "F69",
+    "category": 6,
+    "type": 3,
+    "name": "継戦支援能力の整備",
+    "detail": "艦娘の継戦支援体制の整備強化を実施する！「大口径主砲」系装備x4、「水上偵察機」系装備x2、<br>「魚雷」系装備x3を廃棄、鋼材3,600を準備せよ！　※任務達成後、準備した資源は消費します。",
+    "reward_fuel": 0,
+    "reward_ammo": 500,
+    "reward_steel": 0,
+    "reward_bauxite": 150,
+    "reward_other": [
+      {
+        "name": "高速修复材",
+        "amount": 5
+      }
+    ],
+    "prerequisite": [
+      674
+    ],
+    "requirements": {
+      "category": "equipexchange",
+      "scraps": [
+        {
+          "name": "大口径主砲",
+          "amount": 4
+        },
+        {
+          "name": "水上偵察機",
+          "amount": 2
+        },
+        {
+          "name": "魚雷",
+          "amount": 3
+        }
+      ],
+      "resources": [
+        0,
+        0,
+        3600,
+        0
+      ]
+    }
+  },
+  {
     "game_id": 701,
     "wiki_id": "G01",
     "category": 7,

--- a/quest/poi.json
+++ b/quest/poi.json
@@ -7254,6 +7254,64 @@
     }
   },
   {
+    "game_id": 318,
+    "wiki_id": "C16",
+    "category": 3,
+    "type": 6,
+    "name": "給糧艦「伊良湖」の支援",
+    "detail": "伊良湖支援任務：軽巡を2隻以上配備した第一艦隊で本日中に演習で3回「勝利」、その後、<br>第一艦隊旗艦に戦闘糧食を二つ装備せよ！　※任務達成後、同戦闘糧食は消費します",
+    "reward_fuel": 100,
+    "reward_ammo": 0,
+    "reward_steel": 0,
+    "reward_bauxite": 0,
+    "reward_other": [
+      {
+        "name": "給糧艦「伊良湖」",
+        "amount": 1
+      },
+      {
+        "choices": [
+          {
+            "name": "開発資材",
+            "amount": 2
+          },
+          {
+            "name": "高速修复材",
+            "amount": 2
+          }
+        ]
+      }
+    ],
+    "prerequisite": [
+      676
+    ],
+    "requirements": {
+      "category": "and",
+      "list": [
+        {
+          "category": "excercise",
+          "times": 3,
+          "victory": true,
+          "daily": true,
+          "groups": [
+            {
+              "ship": "軽巡",
+              "amount": 2
+            }
+          ]
+        },
+        {
+          "category": "modelconversion",
+          "secretary": "艦",
+          "equipment": [
+            "戦闘糧食*2"
+          ],
+          "consumptions": []
+        }
+      ]
+    }
+  },
+  {
     "game_id": 401,
     "wiki_id": "D01",
     "category": 4,

--- a/quest/poi.json
+++ b/quest/poi.json
@@ -14994,5 +14994,140 @@
         }
       ]
     }
+  },
+  {
+    "game_id": 877,
+    "wiki_id": "B112",
+    "category": 2,
+    "type": 1,
+    "name": "精鋭「四水戦」、南方海域に展開せよ！",
+    "detail": "「村雨改二」旗艦含む精鋭四水戦(4Sd)より4隻(他主力艦2隻)計6隻の精鋭艦隊を南方海域に展開。<br>南方海域前面、サブ島沖海域、サーモン海域に突入、同南方海域方面の敵艦隊を撃破せよ！",
+    "reward_fuel": 400,
+    "reward_ammo": 400,
+    "reward_steel": 0,
+    "reward_bauxite": 400,
+    "reward_other": [
+      {
+        "choices": [
+          {
+            "name": "12.7cm連装砲C型改二",
+            "amount": 1
+          },
+          {
+            "name": "22号対水上電探",
+            "amount": 2
+          },
+          {
+            "name": "12.7cm連装砲B型改二",
+            "amount": 2
+          }
+        ]
+      },
+      {
+        "choices": [
+          {
+            "name": "洋上補給",
+            "amount": 2
+          },
+          {
+            "name": "ドラム缶(輸送用)",
+            "amount": 3
+          },
+          {
+            "name": "改修資材",
+            "amount": 4
+          }
+        ]
+      }
+    ],
+    "prerequisite": [
+      189
+    ],
+    "requirements": {
+      "category": "and",
+      "list": [
+        {
+          "category": "sortie",
+          "map": "5-1",
+          "times": 1,
+          "boss": true,
+          "result": "A",
+          "groups": [
+            {
+              "ship": "村雨改二",
+              "flagship": true
+            },
+            {
+              "ship": [
+                "由良改二",
+                "夕立改二",
+                "春雨改",
+                "五月雨改",
+                "秋月改"
+              ],
+              "amount": 3
+            },
+            {
+              "ship": "艦",
+              "amount": 2
+            }
+          ]
+        },
+        {
+          "category": "sortie",
+          "map": "5-3",
+          "times": 1,
+          "boss": true,
+          "result": "A",
+          "groups": [
+            {
+              "ship": "村雨改二",
+              "flagship": true
+            },
+            {
+              "ship": [
+                "由良改二",
+                "夕立改二",
+                "春雨改",
+                "五月雨改",
+                "秋月改"
+              ],
+              "amount": 3
+            },
+            {
+              "ship": "艦",
+              "amount": 2
+            }
+          ]
+        },
+        {
+          "category": "sortie",
+          "map": "5-4",
+          "times": 1,
+          "boss": true,
+          "result": "A",
+          "groups": [
+            {
+              "ship": "村雨改二",
+              "flagship": true
+            },
+            {
+              "ship": [
+                "由良改二",
+                "夕立改二",
+                "春雨改",
+                "五月雨改",
+                "秋月改"
+              ],
+              "amount": 3
+            },
+            {
+              "ship": "艦",
+              "amount": 2
+            }
+          ]
+        }
+      ]
+    }
   }
 ]

--- a/quest/poi.json
+++ b/quest/poi.json
@@ -3380,6 +3380,52 @@
     }
   },
   {
+    "game_id": 189,
+    "wiki_id": "A84",
+    "category": 1,
+    "type": 1,
+    "name": "精鋭「四水戦」抜錨準備！",
+    "detail": "四水戦(4Sd)特別編成：「村雨改二」旗艦と精鋭四水戦「由良改二」「夕立改二」「春雨改」「五月雨改」<br>「秋月改」より3隻、さらに主力艦2隻を配備した、有力な特務艦隊を編成、南方海域出撃に備えよ！",
+    "reward_fuel": 0,
+    "reward_ammo": 400,
+    "reward_steel": 0,
+    "reward_bauxite": 0,
+    "reward_other": [
+      {
+        "name": "高速修復材",
+        "amount": 3
+      },
+      {
+        "name": "応急修理女神",
+        "amount": 1
+      }
+    ],
+    "prerequisite": [],
+    "requirements": {
+      "category": "fleet",
+      "groups": [
+        {
+          "ship": "村雨改二",
+          "flagship": true
+        },
+        {
+          "ship": [
+            "由良改二",
+            "夕立改二",
+            "春雨改",
+            "五月雨改",
+            "秋月改"
+          ],
+          "select": 3
+        },
+        {
+          "ship": "艦",
+          "amount": 2
+        }
+      ]
+    }
+  },
+  {
     "game_id": 201,
     "wiki_id": "Bd01",
     "category": 2,

--- a/quest/poi.json
+++ b/quest/poi.json
@@ -14891,5 +14891,108 @@
         }
       ]
     }
+  },
+  {
+    "game_id": 876,
+    "wiki_id": "B111",
+    "category": 2,
+    "type": 1,
+    "name": "松輸送作戦、開始せよ！",
+    "detail": "防衛ラインの強化のため、艦隊旗艦「龍田改二」または「龍田改」、3隻以上の駆逐艦または海防艦を<br>含む輸送護衛艦隊を編成、南西諸島防衛線及び鎮守府近海航路における作戦を複数回成功させよ！",
+    "reward_fuel": 200,
+    "reward_ammo": 200,
+    "reward_steel": 200,
+    "reward_bauxite": 0,
+    "reward_other": [
+      {
+        "choices": [
+          {
+            "name": "新型砲熕兵装資材",
+            "amount": 1
+          },
+          {
+            "name": "新型航空兵装資材",
+            "amount": 1
+          }
+        ]
+      },
+      {
+        "choices": [
+          {
+            "name": "戦闘詳報",
+            "amount": 1
+          },
+          {
+            "name": "特注家具職人",
+            "amount": 1
+          },
+          {
+            "name": "大発動艇",
+            "amount": 1
+          }
+        ]
+      }
+    ],
+    "prerequisite": [
+      673
+    ],
+    "requirements": {
+      "category": "and",
+      "list": [
+        {
+          "category": "sortie",
+          "map": "1-4",
+          "times": 2,
+          "boss": true,
+          "result": "A",
+          "groups": [
+            {
+              "ship": [
+                "龍田改",
+                "龍田改二"
+              ],
+              "flagship": true
+            },
+            {
+              "ship": [
+                "駆逐艦",
+                "海防艦"
+              ],
+              "amount": 3
+            },
+            {
+              "ship": "艦",
+              "amount": 2
+            }
+          ]
+        },
+        {
+          "category": "sortie",
+          "map": "1-6",
+          "times": 2,
+          "groups": [
+            {
+              "ship": [
+                "龍田改",
+                "龍田改二"
+              ],
+              "flagship": true
+            },
+            {
+              "ship": [
+                "駆逐艦",
+                "海防艦"
+              ],
+              "amount": 3
+            },
+            {
+              "ship": "艦",
+              "amount": 2
+            }
+          ],
+          "result": "クリア"
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## 增加新任务

- 189 A84 精鋭「四水戦」抜錨準備！
![image](https://user-images.githubusercontent.com/18554747/35171879-4d083746-fda0-11e7-854d-9960d9a59a3e.png)

- 876 B111 松輸送作戦、開始せよ！
![image](https://user-images.githubusercontent.com/18554747/35171939-7bb58ef4-fda0-11e7-9e1f-af088e3aea89.png)

- 877 B112 精鋭「四水戦」、南方海域に展開せよ！
![image](https://user-images.githubusercontent.com/18554747/35171989-c71c2434-fda0-11e7-8ea5-1b69f44699f0.png)

- 677 F69 継戦支援能力の整備
![image](https://user-images.githubusercontent.com/18554747/35172002-dd4669f4-fda0-11e7-95fe-ad03a7d2d969.png)

- 318 C16 給糧艦「伊良湖」の支援
![image](https://user-images.githubusercontent.com/18554747/35172013-eabdeabc-fda0-11e7-886f-8c351d0870ad.png)
