### PR TITLE
fix quest 部分机种转换任务熟练搭乘员消耗无法显示

### DIFF
--- a/quest/poi.json
+++ b/quest/poi.json
@@ -10214,14 +10214,14 @@
     "requirements": {
       "category": "modelconversion",
       "secretary": "艦",
+      "use_skilled_crew": true,
       "slots": [
         {
           "slot": 1,
           "equipment": "二式水戦改",
           "convert": true,
           "fullyskilled": true,
-          "maxmodified": true,
-          "use_skilled_crew": true
+          "maxmodified": true
         }
       ],
       "scraps": [
@@ -10261,14 +10261,14 @@
     "requirements": {
       "category": "modelconversion",
       "secretary": "艦",
+      "use_skilled_crew": true,
       "slots": [
         {
           "slot": 1,
           "equipment": "二式水戦改",
           "convert": true,
           "fullyskilled": true,
-          "maxmodified": true,
-          "use_skilled_crew": true
+          "maxmodified": true
         }
       ],
       "scraps": [
@@ -10542,13 +10542,13 @@
     "requirements": {
       "category": "modelconversion",
       "secretary": "日向改",
+      "use_skilled_crew": true,
       "slots": [
         {
           "slot": 4,
           "equipment": "瑞雲(六三四空)",
           "convert": true,
-          "maxmodified": true,
-          "use_skilled_crew": true
+          "maxmodified": true
         }
       ],
       "consumptions": [
@@ -10809,12 +10809,12 @@
     "requirements": {
       "category": "modelconversion",
       "secretary": "艦",
+      "use_skilled_crew": true,
       "slots": [
         {
           "slot": 1,
           "equipment": "TBF",
-          "convert": true,
-          "use_skilled_crew": true
+          "convert": true
         }
       ],
       "scraps": [


### PR DESCRIPTION
fix #10 具有`slots`属性的机种转换任务输入格式不正确，导致无法显示任务是否需要消耗熟练搭乘员

影响任务 F51 F52 F58 F62

修改后
- F51
![image](https://user-images.githubusercontent.com/18554747/35184153-bcd522a0-fe2c-11e7-952c-40a6edf1f8a8.png)

- F52
![image](https://user-images.githubusercontent.com/18554747/35184163-e2e4eb2e-fe2c-11e7-8b1e-fa7ad4884d7f.png)

- F58
![image](https://user-images.githubusercontent.com/18554747/35184168-eebfbcb2-fe2c-11e7-8272-553e861964d7.png)

- F62
![image](https://user-images.githubusercontent.com/18554747/35184170-f9c08f4c-fe2c-11e7-91b8-b5ae5d081338.png)
