### PR TITLE
fix quest 318 C16 显示格式

### DIFF
--- a/quest/poi.json
+++ b/quest/poi.json
@@ -7304,7 +7304,8 @@
           "category": "modelconversion",
           "secretary": "艦",
           "equipment": [
-            "戦闘糧食*2"
+            "戦闘糧食",
+            "戦闘糧食"
           ]
         }
       ]

--- a/quest/poi.json
+++ b/quest/poi.json
@@ -7305,8 +7305,7 @@
           "secretary": "艦",
           "equipment": [
             "戦闘糧食*2"
-          ],
-          "consumptions": []
+          ]
         }
       ]
     }


### PR DESCRIPTION
fix #14 #16 仅删除多余的消耗字段，将`["戦闘糧食*2"]`修改为推荐的数组形式

调整后
![image](https://user-images.githubusercontent.com/18554747/35191648-594d3404-febb-11e7-8e27-1e25f7121274.png)

